### PR TITLE
Fix For IdCounter Logic

### DIFF
--- a/Source/Totem/Runtime/Timeline/IdCounter.cs
+++ b/Source/Totem/Runtime/Timeline/IdCounter.cs
@@ -28,7 +28,7 @@ namespace Totem.Runtime.Timeline
 
       _value += 1;
 
-      Next = Id.From(_value);
+      Next = Id.From(_value + 1);
     }
 
     public override string ToString() => Current.ToString();


### PR DESCRIPTION
IdCounter was setting next as it's current value after the first step.
Set so that next would always be set to current value +1