### PR TITLE
Require at least one DateTime to be provided in a ThenSchedule() call

### DIFF
--- a/Source/Totem/Runtime/Timeline/Topic.cs
+++ b/Source/Totem/Runtime/Timeline/Topic.cs
@@ -41,8 +41,9 @@ namespace Totem.Runtime.Timeline
 
 		protected void ThenSchedule(Event e, IEnumerable<TimeSpan> timesOfDay)
 		{
- 			Expect(timesOfDay.Any(), "Event requires at least one time for scheduling.");
- 			ThenSchedule(e, timesOfDay.Select(GetWhenOccursNext).Min());
+			var result = timesOfDay.Select(GetWhenOccursNext).DefaultIfEmpty(DateTime.MinValue).Min();
+			Expect(result > DateTime.MinValue, "Event requires at least one time for scheduling.");
+			ThenSchedule(e, result);
 		}
 
 		protected void ThenSchedule(Event e, params TimeSpan[] timesOfDay)

--- a/Source/Totem/Runtime/Timeline/Topic.cs
+++ b/Source/Totem/Runtime/Timeline/Topic.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -41,7 +41,8 @@ namespace Totem.Runtime.Timeline
 
 		protected void ThenSchedule(Event e, IEnumerable<TimeSpan> timesOfDay)
 		{
-			ThenSchedule(e, timesOfDay.Select(GetWhenOccursNext).Min());
+ 			Expect(timesOfDay.Any(), "Event requires at least one time for scheduling.");
+ 			ThenSchedule(e, timesOfDay.Select(GetWhenOccursNext).Min());
 		}
 
 		protected void ThenSchedule(Event e, params TimeSpan[] timesOfDay)


### PR DESCRIPTION
If you forget to provide a DateTime for scheduling an event, you get a less than helpful "Sequence contains no matching element" error. Adding a check for this case and an error message that's more clear what is wrong.