### PR TITLE
update SignalR to 2.2.2

### DIFF
--- a/Source/Totem.Web/Totem.Web.csproj
+++ b/Source/Totem.Web/Totem.Web.csproj
@@ -36,12 +36,12 @@
     <Reference Include="Autofac">
       <HintPath>..\..\Packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.2.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.Core.2.2.2\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNet.SignalR.SystemWeb, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.2.0\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.SignalR.SystemWeb, Version=2.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.2.2\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.DotNet.InternalAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -157,6 +157,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/Totem.Web/packages.config
+++ b/Source/Totem.Web/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="jQuery" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.AspNet.SignalR" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.AspNet.SignalR.Core" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.AspNet.SignalR.JS" version="2.2.0" targetFramework="net46" />
-  <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.2.0" targetFramework="net46" />
+  <package id="Microsoft.AspNet.SignalR" version="2.2.2" targetFramework="net46" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.2.2" targetFramework="net46" />
+  <package id="Microsoft.AspNet.SignalR.JS" version="2.2.2" targetFramework="net46" />
+  <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.2.2" targetFramework="net46" />
   <package id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Extensions.DependencyModel" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />


### PR DESCRIPTION
We're seeing a memory leak in the Totem SignalR code that looks related to [this issue](https://github.com/SignalR/SignalR/issues/3809), would like to try updating the SignalR version and see if it stops the leak.