### PR TITLE
log exception when it's passed in as a property value

### DIFF
--- a/Source/Totem/LogOperations.cs
+++ b/Source/Totem/LogOperations.cs
@@ -18,7 +18,17 @@ namespace Totem
 
 		public static void At(this ILog log, LogLevel level, Text messageTemplate, params object[] propertyValues)
 		{
-      log.Write(new LogEvent(level, messageTemplate, propertyValues));
+		  if (propertyValues.Length > 0)
+		  {
+		    var ex = propertyValues[0] as Exception;
+		    if (ex != null)
+		    {
+		      log.Write(new LogEvent(ex, level,
+		        $"Error logged with an Exception object as a property value: '{messageTemplate}'", propertyValues));
+		    }
+		  }
+
+		  log.Write(new LogEvent(level, messageTemplate, propertyValues));
     }
 
     public static void At(this ILog log, LogLevel level, Exception error, Text messageTemplate, params object[] propertyValues)


### PR DESCRIPTION
Generally when somebody passes in an Exception object and a string message to a log statement, they want the Exception object to be available in the log client with stack trace and all. However, since log statements in Totem accept a params[] of property values, it's possible to write that code in the wrong order, and it will compile fine. This won't cause any problems until one of these log statements is used, when depending on how the logging client handles property values, the Exception object may silently disappear, or may end up in an unexpected place.

With this new code, if an Exception shows up as the first value in propertyValues, it still gets logged as an exception, with a message warning of the potentially bad method call.