### PR TITLE
call expression with explicit type

### DIFF
--- a/Source/Totem/Runtime/Map/Timeline/KeyedDependency.cs
+++ b/Source/Totem/Runtime/Map/Timeline/KeyedDependency.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -22,7 +22,7 @@ namespace Totem.Runtime.Map.Timeline
 		{
 			// dependencies.ResolveKeyed<T>(Key)
 
-			return Expression.Call(dependencies, "ResolveKeyed", new[] { Parameter.ParameterType }, Expression.Constant(Key));
+			return Expression.Call(dependencies, "ResolveKeyed", new[] { Parameter.ParameterType }, Expression.Constant(Key, typeof(object)));
 		}
 	}
 }


### PR DESCRIPTION
On some environments, calls to resolve keyed dependencies in When()s fail without this parameter