### PR TITLE
Fix hanging requests after a topic stops

### DIFF
--- a/src/Totem.Timeline.EventStore/TimelineDb.cs
+++ b/src/Totem.Timeline.EventStore/TimelineDb.cs
@@ -59,7 +59,16 @@ namespace Totem.Timeline.EventStore
 
     public async Task WriteCheckpoint(Flow flow, TimelinePoint point)
     {
-      var result = await _context.AppendToCheckpoint(flow);
+      WriteResult result;
+
+      try
+      {
+        result = await _context.AppendToCheckpoint(flow);
+      }
+      finally
+      {
+        await TryWriteToClient(flow, point);
+      }
 
       if(flow.Context.IsNew)
       {
@@ -70,8 +79,6 @@ namespace Totem.Timeline.EventStore
       {
         await TryWriteDoneMetadata(flow, result.NextExpectedVersion);
       }
-
-      await TryWriteToClient(flow, point);
     }
 
     async Task TryWriteInitialMetadata(Flow flow)

--- a/src/Totem.Timeline/Runtime/FlowHost.cs
+++ b/src/Totem.Timeline/Runtime/FlowHost.cs
@@ -12,7 +12,6 @@ namespace Totem.Timeline.Runtime
   {
     readonly Dictionary<FlowKey, IFlowScope> _flowsByKey = new Dictionary<FlowKey, IFlowScope>();
     readonly HashSet<FlowKey> _ignored = new HashSet<FlowKey>();
-    readonly HashSet<FlowKey> _stopped = new HashSet<FlowKey>();
     readonly ITimelineDb _db;
     readonly IServiceProvider _services;
 
@@ -71,8 +70,6 @@ namespace Totem.Timeline.Runtime
       catch(Exception error)
       {
         Log.Error(error, "Failed to connect flow {Flow}; treating as stopped", flow.Key);
-
-        _stopped.Add(flow.Key);
       }
     }
 
@@ -84,8 +81,6 @@ namespace Totem.Timeline.Runtime
         if(task.Status == TaskStatus.Faulted)
         {
           Log.Error(task.Exception, "[timeline] Flow lifetime ended with an error");
-
-          _stopped.Add(flow.Key);
         }
         else
         {
@@ -120,11 +115,6 @@ namespace Totem.Timeline.Runtime
 
     async Task Enqueue(TimelinePoint point, FlowKey route)
     {
-      if(_stopped.Contains(route))
-      {
-        return;
-      }
-
       if(!_flowsByKey.TryGetValue(route, out var flow))
       {
         flow = AddFlow(route);

--- a/src/Totem.Timeline/Runtime/FlowScope.cs
+++ b/src/Totem.Timeline/Runtime/FlowScope.cs
@@ -163,9 +163,7 @@ namespace Totem.Timeline.Runtime
     {
       if(Observation.CanBeFirst)
       {
-        Flow = (T) Key.Type.New();
-
-        FlowContext.Bind(Flow, Key);
+        CreateFlow();
       }
       else
       {
@@ -176,12 +174,24 @@ namespace Totem.Timeline.Runtime
       }
     }
 
+    void CreateFlow()
+    {
+      Flow = (T) Key.Type.New();
+
+      FlowContext.Bind(Flow, Key);
+    }
+
     protected abstract Task ObservePoint();
 
     async Task Stop(Exception error)
     {
       try
       {
+        if(Flow == null)
+        {
+          CreateFlow();
+        }
+
         Flow.Context.SetError(Point.Position, error.ToString());
 
         await WriteCheckpoint();


### PR DESCRIPTION
- Write to the client stream whether or not the checkpoint write succeeds
- Do not ignore events routed to stopped flows
- Avoid a null reference when an existing flow fails to load